### PR TITLE
WordPress core does not contain a wp-config.php file; do not require …

### DIFF
--- a/src/Inspectors/WordPressInspector.php
+++ b/src/Inspectors/WordPressInspector.php
@@ -38,12 +38,10 @@ class WordPressInspector implements InspectorInterface
      */
     protected function isWordPressRoot(ComposerInfo $composer_info, $document_root)
     {
-        if (file_exists("$document_root/wp-config.php")) {
-            foreach (['/', '/wp/'] as $dir) {
-                $version_file = $dir . 'wp-includes/version.php';
-                if (file_exists("$document_root/$version_file")) {
-                    return new VersionInfo('WordPress', $composer_info, $document_root, $version_file, "#wp_version = '([0-9.]*)';#m");
-                }
+        foreach (['/', '/wp/'] as $dir) {
+            $version_file = $dir . 'wp-includes/version.php';
+            if (file_exists("$document_root/$version_file")) {
+                return new VersionInfo('WordPress', $composer_info, $document_root, $version_file, "#wp_version = '([0-9.]*)';#m");
             }
         }
         return false;


### PR DESCRIPTION
…that file to be present when detecting WordPress installs.

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
 Has tests?    | yes
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Previously we depended on having a wp-config.php file in the WordPress root. This file is required to run, but is not shipped as part of the repository in WordPress core. We want to be able to detect uninstalled WordPress sites (code only), so we'll remove this check.