### PR TITLE
Make VersionTool account for D7 with relocated root.

### DIFF
--- a/src/Inspectors/Drupal7Inspector.php
+++ b/src/Inspectors/Drupal7Inspector.php
@@ -13,6 +13,13 @@ class Drupal7Inspector implements InspectorInterface
     public function valid(ComposerInfo $composer_info)
     {
         $drupal_root = $composer_info->projectRoot();
+
+        // Determine if there is a relocated drupal root.
+        $core = $composer_info->pathForType('type:drupal-core');
+        if ($core) {
+            $drupal_root = $drupal_root . '/' . $core;
+        }
+
         if (file_exists("$drupal_root/index.php")) {
             // Additional check for the presence of core/composer.json to
             // grant it is not a Drupal 7 site with a base folder named "core".


### PR DESCRIPTION
### Overview
This pull request makes VersionTool to account for Drupal 7 with relocated docroot.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
A Drupal 7 site with a structure like https://github.com/pantheon-systems/example-drops-7-composer will be successfully detected as Drupal 7.

